### PR TITLE
Stanley: Implementation of PayUnit payment gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+/lib/.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,5 @@ gem "net-http"
 gem "faraday"
 
 gem "faraday-net_http"
+
+gem "securerandom"

--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,9 @@ gem "base64"
 gem "httpx"
 
 gem "launchy"
+
+gem "net-http"
+
+gem "faraday"
+
+gem "faraday-net_http"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,10 @@ GEM
     base64 (0.1.1)
     byebug (11.1.3)
     diff-lcs (1.5.0)
+    faraday (2.5.1)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.0)
     http-2-next (0.5.0)
     httpx (0.20.4)
       http-2-next (>= 0.4.1)
@@ -54,6 +58,8 @@ GEM
     rubocop-ast (1.19.1)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
+    securerandom (0.2.0)
     unicode-display_width (2.2.0)
     uri (0.11.0)
 
@@ -63,6 +69,8 @@ PLATFORMS
 DEPENDENCIES
   base64
   byebug
+  faraday
+  faraday-net_http
   httpx
   launchy
   net-http
@@ -70,6 +78,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  securerandom
 
 BUNDLED WITH
    2.3.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     json (2.6.2)
     launchy (2.5.0)
       addressable (~> 2.7)
+    net-http (0.2.2)
+      uri
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -53,6 +55,7 @@ GEM
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.2.0)
+    uri (0.11.0)
 
 PLATFORMS
   x86_64-linux
@@ -62,6 +65,7 @@ DEPENDENCIES
   byebug
   httpx
   launchy
+  net-http
   payunit!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/payunit.rb
+++ b/lib/payunit.rb
@@ -2,8 +2,11 @@
 
 require_relative "payunit/version"
 require "base64"
-require "httpx"
 require "launchy"
+require "byebug"
+require "faraday"
+require "faraday/net_http"
+Faraday.default_adapter = :net_http
 
 class PayUnit
   def initialize(api_key, api_username, api_password, return_url, notify_url, mode, currency)
@@ -23,7 +26,7 @@ class PayUnit
 
     auth = "#{@api_username}:#{@api_password}"
     environment = to_str(@mode)
-    auth_data = Base64.encode64(Base64.encode64(auth))
+    auth_data = Base64.encode64(auth)
     plain = Base64.decode64(auth_data)
 
     test_url = "https://app.payunit.net/api/gateway/initialize"
@@ -39,25 +42,28 @@ class PayUnit
       "notify_url": to_str(@notify_url),
       "total_amount": to_str(amount),
       "return_url": to_str(@return_url),
-      "purchaseRef": to_str(purchaseRef),
-      "description": to_str(description),
-      "name": to_str(name),
-      "currency": to_str(@currency),
-      "transaction_id": to_str(transaction_id)
+      "currency": to_str(@currency)
     }
 
+    # "purchaseRef": to_str(purchaseRef),
+    #   "description": to_str(description),
+    #   "name": to_str(name),
+    #   "transaction_id": to_str(transaction_id)
+
     begin
-      response = HTTPX.post(
-        test_url, test_body.to_json, headers: headers
+      conn = Faraday.new(
+        url: "https://app.payunit.net/api/gateway/initialize",
+        params: { param: "1" },
+        headers: headers
       )
+      response = conn.post(test_url, test_body.to_json, headers)
+
       response = response.to_json
 
-      if response.statusCode == 200
-        Launchy.open(response["data"]["transaction_url"])
-        { "message": "Successfylly initated Transaction", "statusCode": response["statusCode"] }
-      else
-        raise response["message"]
-      end
+      raise response["message"] unless response.status == 200
+
+      Launchy.open(response["data"]["transaction_url"])
+      { "message": "Successfylly initated Transaction", "statusCode": response["statusCode"] }
     rescue StandardError => e
       abort(response["statusCode"], response["message"])
     end
@@ -87,14 +93,13 @@ class PayUnit
     raise "Invalid sdk mode" if @mode.downcase != "test" && @mode.downcase != "live"
   end
 end
-api_key = "payunit_uWNwsqbl9"
-api_password = "3456656ff1207e61b49fd1026739831d365022f1"
-api_username = "apiUser"
-return_url = "returnUrl"
-notify_url = "notifyUrl"
-currency = "currency"
-mode = "test"
+api_key = "3456656ff1207e61b49fd1026739831d365022f1"
+api_password = "bf871f50-3cc9-42df-a7d5-eac2536c7130"
+api_username = "payunit_uWNwsqbl9"
+return_url = "https://aproplat.com"
+notify_url = "https://aproplat.com"
+currency = "XAF"
+mode = "live"
 
 payment = PayUnit.new(api_key, api_username, api_password, return_url, notify_url, mode, currency)
 payment.make_payment(500)
-puts payment

--- a/lib/payunit.rb
+++ b/lib/payunit.rb
@@ -27,8 +27,7 @@ class PayUnit
 
     auth = "#{@api_username}:#{@api_password}"
     environment = to_str(@mode)
-    auth_data = Base64.encode64(auth)
-    plain = Base64.decode64(auth_data)
+    auth_data = Base64.strict_encode64(auth)
     transaction_id = SecureRandom.uuid
 
     test_url = "https://app.payunit.net/api/gateway/initialize"
@@ -36,7 +35,7 @@ class PayUnit
     headers = {
       "x-api-key": to_str(@api_key),
       "content-type": "application/json",
-      "Authorization": "Basic #{(auth_data)}",
+      "Authorization": "Basic #{to_str(auth_data)}",
       "mode": to_str(environment.downcase)
     }
 


### PR DESCRIPTION
This PR implements the following:

1. Define PayUnit Ruby Class
2. Add PayUnit Initialize method
3. Add PayUnit ```make_payment()``` method
4. Add supporting gems

The code implements the exact implementation of PayUnit python sdk.

Thank you Stanley